### PR TITLE
14 generate kafka messages

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -830,6 +830,20 @@ files = [
 referencing = ">=0.31.0"
 
 [[package]]
+name = "kafka-python"
+version = "2.0.2"
+description = "Pure Python client for Apache Kafka"
+optional = false
+python-versions = "*"
+files = [
+    {file = "kafka-python-2.0.2.tar.gz", hash = "sha256:04dfe7fea2b63726cd6f3e79a2d86e709d608d74406638c5da33a01d45a9d7e3"},
+    {file = "kafka_python-2.0.2-py2.py3-none-any.whl", hash = "sha256:2d92418c7cb1c298fa6c7f0fb3519b520d0d7526ac6cb7ae2a4fc65a51a94b6e"},
+]
+
+[package.extras]
+crc32c = ["crc32c"]
+
+[[package]]
 name = "keystoneauth1"
 version = "5.6.0"
 description = "Authentication Library for OpenStack Identity"
@@ -2360,4 +2374,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "ff47a17a085f7e68082187fe5a765ff2504ce65d601e9ac2899fcfb820d9fd31"
+content-hash = "972fc6b4e73db9ae3ee542508d8dcf683593d89f1dd0629ebd902b2984cc5115"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python-openstackclient = "^6.2.0"
 python-glanceclient = "^4.4.0"
 federation-registry = {git = "https://github.com/infn-datacloud/federation-registry.git"}
 liboidcagent = "^0.6" # {git = "https://github.com/giosava94/liboidc-agent-py.git", branch = "local-and-remote" }
+kafka-python = "^2.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"

--- a/src/config.py
+++ b/src/config.py
@@ -86,6 +86,12 @@ class Settings(BaseSettings):
         default=None,
         description="Name of the container with the oidc-agent service instance.",
     )
+    KAFKA_SERVER_URL: str | None = Field(
+        default=None, description="Kafka server url"
+    )
+    KAFKA_TOPIC: str | None = Field(
+        default=None, description="Kafka topic to upload data"
+    )
     api_ver: APIVersions = Field(description="API versions.")
 
     @validator("PROVIDERS_CONF_DIR")

--- a/src/kafka_conn.py
+++ b/src/kafka_conn.py
@@ -1,0 +1,30 @@
+import json
+from typing import Any
+
+from kafka import KafkaProducer
+
+
+class Producer:
+    """Producer instance to send messages to kafka"""
+
+    def __init__(
+        self,
+        *,
+        server_url: str,
+        topic: str,
+        client_id: str = "Federation-Registry-Feeder",
+        **kwargs,
+    ) -> None:
+        self.server_url = server_url
+        self.topic = topic
+        self.client_id = client_id
+        self.producer = KafkaProducer(
+            bootstrap_servers=self.server_url,
+            client_id=client_id,
+            value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+            **kwargs,
+        )
+
+    def send(self, data: dict[str, Any]):
+        """Send message to kafka"""
+        self.producer.send(self.topic, data)


### PR DESCRIPTION
When collecting providers data, optionally send quota limitations and usage to a kafka server. 
To enable this functionality, during installation, the admin must set KAFKA_SERVER_URL and KAFKA_TOPIC environment variables.
This PR closes #14 