### PR TITLE
Set default network when only one

### DIFF
--- a/tests/providers/openstack/test_network_services.py
+++ b/tests/providers/openstack/test_network_services.py
@@ -176,10 +176,7 @@ def test_retrieve_network_service_networks_tags(
     assert item is not None
 
     mock_networks.assert_called_once_with(
-        default_private_net=None,
-        default_public_net=None,
-        proxy=None,
-        tags=openstack_item.provider_conf.network_tags,
+        proxy=None, tags=openstack_item.provider_conf.network_tags
     )
 
 
@@ -213,8 +210,5 @@ def test_retrieve_network_service_default_net(
     assert item is not None
 
     mock_networks.assert_called_once_with(
-        default_private_net=openstack_item.project_conf.default_private_net,
-        default_public_net=openstack_item.project_conf.default_public_net,
-        proxy=openstack_item.project_conf.private_net_proxy,
-        tags=[],
+        proxy=openstack_item.project_conf.private_net_proxy, tags=[]
     )

--- a/tests/schemas/utils.py
+++ b/tests/schemas/utils.py
@@ -32,6 +32,10 @@ def location_dict() -> dict[str, Any]:
     return {"site": random_lower_string(), "country": random_country()}
 
 
+def network_dict() -> dict[str, Any]:
+    return {"name": random_lower_string(), "uuid": uuid4()}
+
+
 def openstack_dict() -> dict[str, Any]:
     """Dict with openstack provider minimal attributes."""
     return {"name": random_lower_string(), "auth_url": random_url()}


### PR DESCRIPTION
When a project has only one public (private) network, and a default public (private) one has not been specified, mark that network as default