### PR TITLE
Fix networks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -549,8 +549,8 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "htt
 
 [[package]]
 name = "fedreg"
-version = "0.1.0"
-description = "Python web application providing public REST API to inspect the configurations of the providers registered into the DataCloud project"
+version = "1.0.1"
+description = "Python library with the Object Models used in the federation-registry app."
 optional = false
 python-versions = ">=3.9,<4.0.0"
 files = []
@@ -564,8 +564,8 @@ pydantic = {version = ">=1.10.9,<2.0.0", extras = ["email"]}
 [package.source]
 type = "git"
 url = "https://github.com/infn-datacloud/federation-registry-lib.git"
-reference = "v1.0.0"
-resolved_reference = "5d347399688f0f76529597b4c6e3f757c44c19ab"
+reference = "networks-multi-projects"
+resolved_reference = "9d7203320233319d4ecd7215c03bbf83d8766f81"
 
 [[package]]
 name = "filelock"
@@ -2141,4 +2141,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2,<4.0.0"
-content-hash = "ad84514032a4a31ff5ac37836689a6d3291c7b27419ec0fb7f87121759e18064"
+content-hash = "547e1ed424e917e0e8c8666bf93176ca6be0a41cd7bd70cccb7b6f37e0eddd85"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python-openstackclient = "^6.2.0"
 python-glanceclient = "^4.4.0"
 kafka-python = "^2.0.2"
 fastapi = "^0.115.8"
-fedreg = {git = "https://github.com/infn-datacloud/federation-registry-lib.git", tag = "v1.0.0"}
+fedreg = {git = "https://github.com/infn-datacloud/federation-registry-lib.git", branch = "networks-multi-projects"}
 liboidcagent = "^0.6"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/utils.py
+++ b/src/utils.py
@@ -152,14 +152,17 @@ def get_updated_networks(
     If the service does not exist, add it; otherwise, add new quotas, flavors and
     images.
     """
-    resources = []
+    resources = [*current_resources]
     for new_res in new_resources:
         for curr_res in current_resources:
             if new_res.uuid == curr_res.uuid:
                 if isinstance(new_res, PrivateNetworkCreateExtended) and isinstance(
                     curr_res, PrivateNetworkCreateExtended
                 ):
-                    new_res.projects += curr_res.projects
+                    new_res.projects = list(
+                        set(new_res.projects).union(curr_res.projects)
+                    )
+                resources.remove(curr_res)
                 resources.append(new_res)
                 break
         else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,14 +7,18 @@ from fedreg.provider.enum import ProviderStatus
 from fedreg.provider.schemas_extended import (
     BlockStorageServiceCreateExtended,
     ComputeServiceCreateExtended,
-    FlavorCreateExtended,
     IdentityProviderCreateExtended,
-    ImageCreateExtended,
     NetworkServiceCreateExtended,
     ObjectStoreServiceCreateExtended,
+    PrivateFlavorCreateExtended,
+    PrivateImageCreateExtended,
+    PrivateNetworkCreateExtended,
     ProjectCreate,
     ProviderCreateExtended,
     RegionCreateExtended,
+    SharedFlavorCreate,
+    SharedImageCreate,
+    SharedNetworkCreate,
 )
 from liboidcagent.liboidcagent import OidcAgentConnectError, OidcAgentError
 from pydantic import ValidationError
@@ -99,9 +103,9 @@ def get_site_configs(
 
 def filter_compute_resources_projects(
     *,
-    items: list[FlavorCreateExtended] | list[ImageCreateExtended],
+    items: list[PrivateFlavorCreateExtended] | list[PrivateImageCreateExtended],
     projects: list[str],
-) -> list[FlavorCreateExtended] | list[ImageCreateExtended]:
+) -> list[PrivateFlavorCreateExtended] | list[PrivateImageCreateExtended]:
     """Remove from compute resources projects not imported in the Fed-Reg.
 
     Apply the filtering only on private flavors and images.
@@ -111,7 +115,7 @@ def filter_compute_resources_projects(
     there can't be an empty projects list.
     """
     for item in items:
-        if not item.is_public:
+        if not item.is_shared:
             item.projects = list(
                 filter(lambda x, projects=projects: x in projects, item.projects)
             )
@@ -138,18 +142,40 @@ def get_updated_identity_provider(
     return current_idp
 
 
+def get_updated_networks(
+    *,
+    current_resources: list[PrivateNetworkCreateExtended | SharedNetworkCreate],
+    new_resources: list[PrivateNetworkCreateExtended | SharedNetworkCreate],
+) -> list[PrivateNetworkCreateExtended | SharedNetworkCreate]:
+    """Update Compute services.
+
+    If the service does not exist, add it; otherwise, add new quotas, flavors and
+    images.
+    """
+    resources = []
+    for new_res in new_resources:
+        for curr_res in current_resources:
+            if new_res.uuid == curr_res.uuid:
+                if isinstance(new_res, PrivateNetworkCreateExtended) and isinstance(
+                    curr_res, PrivateNetworkCreateExtended
+                ):
+                    new_res.projects += curr_res.projects
+                resources.append(new_res)
+                break
+        else:
+            resources.append(new_res)
+    return resources
+
+
 def get_updated_resources(
     *,
-    current_resources: list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkServiceCreateExtended],
-    new_resources: list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkServiceCreateExtended],
+    current_resources: list[PrivateFlavorCreateExtended | SharedFlavorCreate]
+    | list[PrivateImageCreateExtended | SharedImageCreate],
+    new_resources: list[PrivateFlavorCreateExtended | SharedFlavorCreate]
+    | list[PrivateImageCreateExtended | SharedImageCreate],
 ) -> (
-    list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkServiceCreateExtended]
+    list[PrivateFlavorCreateExtended | SharedFlavorCreate]
+    | list[PrivateImageCreateExtended | SharedImageCreate]
 ):
     """Update Compute services.
 
@@ -199,7 +225,7 @@ def update_service(
             new_resources=new_service.images,
         )
     if isinstance(curr_service, NetworkServiceCreateExtended):
-        curr_service.networks = get_updated_resources(
+        curr_service.networks = get_updated_networks(
             current_resources=curr_service.networks,
             new_resources=new_service.networks,
         )

--- a/tests/fed_reg/test_get_updated_resources.py
+++ b/tests/fed_reg/test_get_updated_resources.py
@@ -1,44 +1,115 @@
 from uuid import uuid4
 
 from fedreg.provider.schemas_extended import (
-    FlavorCreateExtended,
-    ImageCreateExtended,
-    NetworkCreateExtended,
+    PrivateFlavorCreateExtended,
+    PrivateImageCreateExtended,
+    PrivateNetworkCreateExtended,
+    SharedFlavorCreate,
+    SharedImageCreate,
+    SharedNetworkCreate,
 )
-from pytest_cases import parametrize_with_cases
+from pytest_cases import case, parametrize_with_cases
 
-from src.utils import get_updated_resources
+from src.utils import get_updated_networks, get_updated_resources
 from tests.utils import random_lower_string
 
 
 class CaseResources:
-    def case_flavors(self) -> list[FlavorCreateExtended]:
+    @case(tags="shared")
+    def case_pub_flavors(self) -> list[SharedFlavorCreate]:
         return [
-            FlavorCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            FlavorCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            FlavorCreateExtended(name=random_lower_string(), uuid=uuid4()),
+            SharedFlavorCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedFlavorCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedFlavorCreate(name=random_lower_string(), uuid=uuid4()),
         ]
 
-    def case_images(self) -> list[ImageCreateExtended]:
+    @case(tags="private")
+    def case_priv_flavors(self) -> list[PrivateFlavorCreateExtended]:
+        project1 = uuid4()
+        project2 = uuid4()
         return [
-            ImageCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            ImageCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            ImageCreateExtended(name=random_lower_string(), uuid=uuid4()),
+            PrivateFlavorCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateFlavorCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateFlavorCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project2]
+            ),
         ]
 
-    def case_networks(self) -> list[NetworkCreateExtended]:
+    @case(tags="shared")
+    def case_pub_images(self) -> list[SharedImageCreate]:
         return [
-            NetworkCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            NetworkCreateExtended(name=random_lower_string(), uuid=uuid4()),
-            NetworkCreateExtended(name=random_lower_string(), uuid=uuid4()),
+            SharedImageCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedImageCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedImageCreate(name=random_lower_string(), uuid=uuid4()),
+        ]
+
+    @case(tags="private")
+    def case_priv_images(self) -> list[PrivateImageCreateExtended]:
+        project1 = uuid4()
+        project2 = uuid4()
+        return [
+            PrivateImageCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateImageCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateImageCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project2]
+            ),
+        ]
+
+
+class CaseNetworks:
+    @case(tags="shared")
+    def case_pub_networks(self) -> list[SharedNetworkCreate]:
+        return [
+            SharedNetworkCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedNetworkCreate(name=random_lower_string(), uuid=uuid4()),
+            SharedNetworkCreate(name=random_lower_string(), uuid=uuid4()),
+        ]
+
+    @case(tags="private")
+    def case_priv_networks(self) -> list[PrivateNetworkCreateExtended]:
+        project1 = uuid4()
+        project2 = uuid4()
+        return [
+            PrivateNetworkCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateNetworkCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project1]
+            ),
+            PrivateNetworkCreateExtended(
+                name=random_lower_string(), uuid=uuid4(), projects=[project2]
+            ),
+        ]
+
+    @case(tags=("private", "same-id-diff-proj"))
+    def case_same_net_diff_proj(self) -> list[PrivateNetworkCreateExtended]:
+        net_id = uuid4()
+        name = random_lower_string()
+        project = uuid4()
+        return [
+            PrivateNetworkCreateExtended(
+                name=name, uuid=net_id, projects=[project, uuid4()]
+            ),
+            PrivateNetworkCreateExtended(
+                name=name, uuid=net_id, projects=[project, uuid4()]
+            ),
         ]
 
 
 @parametrize_with_cases("resources", cases=CaseResources)
 def test_identical_resources(
-    resources: list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkCreateExtended],
+    resources: list[SharedFlavorCreate]
+    | list[PrivateFlavorCreateExtended]
+    | list[SharedImageCreate]
+    | list[PrivateImageCreateExtended],
 ) -> None:
     curr_res = resources[0:1]
     new_res = resources[0:1]
@@ -50,9 +121,10 @@ def test_identical_resources(
 
 @parametrize_with_cases("resources", cases=CaseResources)
 def test_add_new_resources(
-    resources: list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkCreateExtended],
+    resources: list[SharedFlavorCreate]
+    | list[PrivateFlavorCreateExtended]
+    | list[SharedImageCreate]
+    | list[PrivateImageCreateExtended],
 ) -> None:
     curr_res = resources[0:1]
     new_res = resources[1:]
@@ -64,9 +136,10 @@ def test_add_new_resources(
 
 @parametrize_with_cases("resources", cases=CaseResources)
 def test_add_only_new_resources(
-    resources: list[FlavorCreateExtended]
-    | list[ImageCreateExtended]
-    | list[NetworkCreateExtended],
+    resources: list[SharedFlavorCreate]
+    | list[PrivateFlavorCreateExtended]
+    | list[SharedImageCreate]
+    | list[PrivateImageCreateExtended],
 ) -> None:
     curr_res = resources[0:1]
     new_res = resources
@@ -74,3 +147,54 @@ def test_add_only_new_resources(
         current_resources=curr_res, new_resources=new_res
     )
     assert len(update_resources) == 3
+
+
+@parametrize_with_cases("networks", cases=CaseNetworks)
+def test_identical_networks(
+    networks: list[SharedNetworkCreate] | list[PrivateNetworkCreateExtended],
+) -> None:
+    curr_res = networks[0:1]
+    new_res = networks[0:1]
+    update_networks = get_updated_networks(
+        current_resources=curr_res, new_resources=new_res
+    )
+    assert len(update_networks) == 1
+    if isinstance(update_networks[0], PrivateNetworkCreateExtended):
+        assert len(update_networks[0].projects) == 1
+
+
+@parametrize_with_cases("networks", cases=CaseNetworks)
+def test_add_new_networks(
+    networks: list[SharedNetworkCreate] | list[PrivateNetworkCreateExtended],
+) -> None:
+    curr_res = networks[0:1]
+    new_res = networks[1:]
+    update_networks = get_updated_networks(
+        current_resources=curr_res, new_resources=new_res
+    )
+    assert len(update_networks) == 3
+
+
+@parametrize_with_cases("networks", cases=CaseNetworks)
+def test_add_only_new_networks(
+    networks: list[SharedNetworkCreate] | list[PrivateNetworkCreateExtended],
+) -> None:
+    curr_res = networks[0:1]
+    new_res = networks
+    update_networks = get_updated_networks(
+        current_resources=curr_res, new_resources=new_res
+    )
+    assert len(update_networks) == 3
+
+
+@parametrize_with_cases("networks", cases=CaseNetworks, has_tag="same-id-diff-proj")
+def test_update_only_network_projects(
+    networks: list[SharedNetworkCreate] | list[PrivateNetworkCreateExtended],
+) -> None:
+    curr_res = networks[0:1]
+    new_res = networks[1:]
+    update_networks = get_updated_networks(
+        current_resources=curr_res, new_resources=new_res
+    )
+    assert len(update_networks) == 1
+    assert len(update_networks[0].projects) == 3

--- a/tests/fed_reg/test_get_updated_services.py
+++ b/tests/fed_reg/test_get_updated_services.py
@@ -133,10 +133,7 @@ def test_update_existing_service_quotas(
 
 @parametrize_with_cases("services", cases=CaseService, has_tag="flavor")
 def test_update_existing_service_flavors(
-    services: list[BlockStorageServiceCreateExtended]
-    | list[ComputeServiceCreateExtended]
-    | list[NetworkServiceCreateExtended]
-    | list[ObjectStoreServiceCreateExtended],
+    services: list[ComputeServiceCreateExtended],
 ) -> None:
     curr_srv = services[:1]
     new_srv = copy.deepcopy(services[:1])
@@ -151,10 +148,7 @@ def test_update_existing_service_flavors(
 
 @parametrize_with_cases("services", cases=CaseService, has_tag="image")
 def test_update_existing_service_images(
-    services: list[BlockStorageServiceCreateExtended]
-    | list[ComputeServiceCreateExtended]
-    | list[NetworkServiceCreateExtended]
-    | list[ObjectStoreServiceCreateExtended],
+    services: list[ComputeServiceCreateExtended],
 ) -> None:
     curr_srv = services[:1]
     new_srv = copy.deepcopy(services[:1])
@@ -169,10 +163,7 @@ def test_update_existing_service_images(
 
 @parametrize_with_cases("services", cases=CaseService, has_tag="network")
 def test_update_existing_service_networks(
-    services: list[BlockStorageServiceCreateExtended]
-    | list[ComputeServiceCreateExtended]
-    | list[NetworkServiceCreateExtended]
-    | list[ObjectStoreServiceCreateExtended],
+    services: list[NetworkServiceCreateExtended],
 ) -> None:
     curr_srv = services[:1]
     new_srv = copy.deepcopy(services[:1])

--- a/tests/fed_reg/test_merge_components.py
+++ b/tests/fed_reg/test_merge_components.py
@@ -2,9 +2,9 @@ import copy
 from uuid import uuid4
 
 from fedreg.provider.schemas_extended import (
-    FlavorCreateExtended,
     IdentityProviderCreateExtended,
-    ImageCreateExtended,
+    PrivateFlavorCreateExtended,
+    PrivateImageCreateExtended,
     ProjectCreate,
     RegionCreateExtended,
 )
@@ -73,7 +73,7 @@ def test_merge_components_multi_entries_filter_projects(
     region_create: RegionCreateExtended,
 ):
     region_create.compute_services[0].flavors.append(
-        FlavorCreateExtended(
+        PrivateFlavorCreateExtended(
             name=random_lower_string(),
             uuid=uuid4(),
             is_public=False,
@@ -81,7 +81,7 @@ def test_merge_components_multi_entries_filter_projects(
         )
     )
     region_create.compute_services[0].images.append(
-        ImageCreateExtended(
+        PrivateImageCreateExtended(
             name=random_lower_string(),
             uuid=uuid4(),
             is_public=False,

--- a/tests/providers/openstack/test_compute_services.py
+++ b/tests/providers/openstack/test_compute_services.py
@@ -5,8 +5,10 @@ from uuid import uuid4
 from fedreg.provider.schemas_extended import (
     ComputeQuotaCreateExtended,
     ComputeServiceCreateExtended,
-    FlavorCreateExtended,
-    ImageCreateExtended,
+    PrivateFlavorCreateExtended,
+    PrivateImageCreateExtended,
+    SharedFlavorCreate,
+    SharedImageCreate,
 )
 from fedreg.service.enum import ComputeServiceName, ServiceType
 from keystoneauth1.exceptions.catalog import EndpointNotFound
@@ -125,11 +127,11 @@ def test_retrieve_compute_service_with_flavors(
     """Check flavors in the returned service."""
     if visibility == "public":
         mock_flavors.return_value = [
-            FlavorCreateExtended(uuid=uuid4(), name=random_lower_string())
+            SharedFlavorCreate(uuid=uuid4(), name=random_lower_string())
         ]
     elif visibility == "private":
         mock_flavors.return_value = [
-            FlavorCreateExtended(
+            PrivateFlavorCreateExtended(
                 uuid=uuid4(),
                 name=random_lower_string(),
                 is_public=False,
@@ -164,11 +166,11 @@ def test_retrieve_compute_service_with_images(
     """Check images in the returned service."""
     if visibility == "public":
         mock_images.return_value = [
-            ImageCreateExtended(uuid=uuid4(), name=random_lower_string())
+            SharedImageCreate(uuid=uuid4(), name=random_lower_string())
         ]
     elif visibility == "private":
         mock_images.return_value = [
-            ImageCreateExtended(
+            PrivateImageCreateExtended(
                 uuid=uuid4(),
                 name=random_lower_string(),
                 is_public=False,

--- a/tests/providers/openstack/test_images.py
+++ b/tests/providers/openstack/test_images.py
@@ -1,7 +1,10 @@
 from unittest.mock import Mock, PropertyMock, patch
 from uuid import uuid4
 
-from fedreg.provider.schemas_extended import ImageCreateExtended
+from fedreg.provider.schemas_extended import (
+    PrivateImageCreateExtended,
+    SharedImageCreate,
+)
 from openstack.image.v2.image import Image
 from openstack.image.v2.member import Member
 from pytest_cases import case, parametrize, parametrize_with_cases
@@ -105,7 +108,7 @@ def test_retrieve_public_images(
     assert len(data) == 1
     if len(data) > 0:
         item = data[0]
-        assert isinstance(item, ImageCreateExtended)
+        assert isinstance(item, SharedImageCreate)
         assert item.description == ""
         assert item.uuid == openstack_image.id
         assert item.name == openstack_image.name
@@ -117,8 +120,7 @@ def test_retrieve_public_images(
         assert not item.cuda_support
         assert not item.gpu_driver
         assert item.tags == openstack_image.tags
-        assert item.is_public
-        assert len(item.projects) == 0
+        assert item.is_shared
 
 
 @patch("src.providers.openstack.Connection")
@@ -216,6 +218,5 @@ def test_retrieve_private_images(
     data = openstack_item.get_images()
     assert len(data) == 1
     item = data[0]
-    assert isinstance(item, ImageCreateExtended)
-    assert not item.is_public
+    assert isinstance(item, PrivateImageCreateExtended)
     assert item.projects[0] == openstack_item.project_conf.id

--- a/tests/providers/openstack/test_network_services.py
+++ b/tests/providers/openstack/test_network_services.py
@@ -3,9 +3,10 @@ from unittest.mock import Mock, PropertyMock, patch
 from uuid import uuid4
 
 from fedreg.provider.schemas_extended import (
-    NetworkCreateExtended,
     NetworkQuotaCreateExtended,
     NetworkServiceCreateExtended,
+    PrivateNetworkCreateExtended,
+    SharedNetworkCreate,
 )
 from fedreg.service.enum import NetworkServiceName, ServiceType
 from keystoneauth1.exceptions.catalog import EndpointNotFound
@@ -126,15 +127,15 @@ def test_retrieve_network_service_with_networks(
     """Check networks in the returned service."""
     if visibility == "public":
         mock_networks.return_value = [
-            NetworkCreateExtended(uuid=uuid4(), name=random_lower_string())
+            SharedNetworkCreate(uuid=uuid4(), name=random_lower_string())
         ]
     elif visibility == "private":
         mock_networks.return_value = [
-            NetworkCreateExtended(
+            PrivateNetworkCreateExtended(
                 uuid=uuid4(),
                 name=random_lower_string(),
                 is_shared=False,
-                project=openstack_item.project_conf.id,
+                projects=[openstack_item.project_conf.id],
             )
         ]
     elif visibility == "no-access":


### PR DESCRIPTION
Update fedreg library. Networks can support multiple projects.
Not owned and not shared networks which are still usable by a project are not discarded.